### PR TITLE
fix:  template 数据结构调整，移除 workflow，直接给 param_list；request 封装里新增了本地调试时的选项

### DIFF
--- a/config/index.js
+++ b/config/index.js
@@ -5,6 +5,7 @@ export const config = {
   cloudEnv: 'creart-test-1g2yuv6d82b517bf',
   log: true,
   host: '101.43.108.238:8000',
+  // host: '127.0.0.1:8000'
 };
 
 export const cdnBase =

--- a/pages/workflow/generate/index.js
+++ b/pages/workflow/generate/index.js
@@ -87,29 +87,50 @@ Page({
       const formData = [];
       let formImage = null;
 
-      Object.keys(data.workflow.params).forEach(key => {
-        const item = data.workflow.params[key];
-        if (item?.type === 'image') {
+      // Object.keys(data.workflow.params).forEach(key => {
+      //   const item = data.workflow.params[key];
+      //   if (item?.type === 'image') {
+      //     formImage = {
+      //       ...item,
+      //       key
+      //     };
+      //   } else {
+      //     if (item.type === 'select' && item.options) {
+      //       item.keys = item.options.map(option => option.key)
+      //       // Object.keys(item.options);
+      //       if (item.required && item.default) {
+      //         formValue[key] = item.default;
+      //       }
+      //     }
+      //     formData.push({
+      //       ...item,
+      //       key
+      //     });
+      //   }
+      // });
+      data.param_list.forEach(item => {
+        const { key, type, options, required, default: defaultValue } = item;
+
+        if (type === 'image') {
           formImage = {
             ...item,
             key
           };
         } else {
-          if (item.type === 'select' && item.options) {
-            item.keys = item.options.map(option => option.key)
-            // Object.keys(item.options);
-            if (item.required && item.default) {
-              formValue[key] = item.default;
+          if (type === 'select' && options) {
+            item.keys = options.map(option => option.key);
+            if (required && defaultValue) {
+              formValue[key] = defaultValue;
             }
           }
           formData.push({
             ...item,
-            key
+            // key
           });
         }
       });
-
-      console.log(formValue);
+      console.log('formData', formData);
+      console.log('formValue', formValue);
 
       this.setData({
         template: data,


### PR DESCRIPTION
- 本地调试时，判断 127.0.0.1 则直接用原生 wx.request 调用本地接口，不再调用云函数
- 本地调试时，上传图片直接调用 wx.uploadFile，不再调用云函数
- fetchTemlateList，调整了返回数据结构，移除 workflow，用 data.param_list 计算 formData和 formValue

Changes to be committed:
	modified:   config/index.js
	modified:   pages/workflow/generate/index.js
	modified:   services/_utils/request.js